### PR TITLE
Wolfe sevices dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,3 +332,4 @@ ASALocalRun/
 
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
+docker-compose.yml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # stuff
 wip.md
 mcserver/
+docker-compose.yml
 
 # User-specific files
 *.suo

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 # stuff
 wip.md
 mcserver/
-docker-compose.yml
 
 # User-specific files
 *.suo

--- a/README.md
+++ b/README.md
@@ -120,6 +120,14 @@ This image has seven environment variables:
   - Set to any additional Java command line options that you would like to include.
   - By default, this environment variable is set to the empty string.
   - `-e JAVA_OPTS="<-XX:+UseConcMarkSweepGC -XX:+UseParNewGC>"`
+- Custom Run command
+  - **Name:** `RUN_COMMAND`
+  - **ADVANCED USERS ONLY**
+  - Set to the name of the custom server jar you want to use.
+  - also allows pointing to a scrpt file, this reqires the full path to the file.
+  - For more information, see [Lazymc's documentation](https://github.com/timvisee/lazymc/blob/master/docs/command-bash.md).
+  - By default, this environment variable is set to the empty string.
+  - `-e RUN_COMMAND="<custom.jar>"` or `-e RUN_COMMAND="/mcserver/<custom.sh>"`
 
 ## Further Setup
 From this point, the server should be configured in the same way as any other Minecraft server. The server's files, including `server.properties`, can be found in the volume that was specified earlier. The port that was specified earlier will probably need to be forwarded as well. For details on how to do this and other such configuration, Google it, because it works the same as any other Minecraft server.

--- a/mcserver.sh
+++ b/mcserver.sh
@@ -219,13 +219,21 @@ then
   if ! grep -q "mcserver-lazymc-docker" lazymc.toml;
   then
     # Add the comment to the file
-    sed -i '/Command to start the server/i # Managed by mcserver-lazymc-docker, please do not edit this!' lazymc.toml
+    sed -i '/Command to start the server/i # Managed by mcserver-lazymc-docker, please do not edit this! Use the MC_COMMAND Enviroment variable to set.' lazymc.toml
   fi
-  if ! sed -i "s~command = .*~command = \"java $JAVA_OPTS -jar $JAR_NAME nogui\"~" lazymc.toml
+  if $MC_COMMAND != ""
   then
-    echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
-    exit 1
-  fi
+    if ! sed -i "s/command = .*/command = \"$MC_COMMAND\"/" lazymc.toml
+    then
+      echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
+      exit 1
+    fi
+  else
+    if ! sed -i "s/command = .*/command = \"java $JAVA_OPTS -jar $JAR_NAME nogui\"/" lazymc.toml
+    then
+      echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
+      exit 1
+    fi
 fi
 
 # Server launch handler
@@ -234,10 +242,19 @@ then
   # Start directly the server when lazymc is disabled
   echo "\033[0;33mStarting the server! \033[0m"
   echo ""
-  if ! java $JAVA_OPTS -jar $JAR_NAME nogui
+  if $MC_COMMAND != ""
   then
-    echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
-    exit 1
+    if ! $MC_COMMAND
+    then
+      echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
+      exit 1
+    fi
+  else
+    if ! java $JAVA_OPTS -jar $JAR_NAME nogui
+    then
+      echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
+      exit 1
+    fi
   fi
 else
   echo "\033[0;33mStarting the server! \033[0m"

--- a/mcserver.sh
+++ b/mcserver.sh
@@ -219,21 +219,13 @@ then
   if ! grep -q "mcserver-lazymc-docker" lazymc.toml;
   then
     # Add the comment to the file
-    sed -i '/Command to start the server/i # Managed by mcserver-lazymc-docker, please do not edit this! Use the MC_COMMAND Enviroment variable to set.' lazymc.toml
+    sed -i '/Command to start the server/i # Managed by mcserver-lazymc-docker, please do not edit this!' lazymc.toml
   fi
-  if $MC_COMMAND != ""
+  if ! sed -i "s~command = .*~command = \"java $JAVA_OPTS -jar $JAR_NAME nogui\"~" lazymc.toml
   then
-    if ! sed -i "s/command = .*/command = \"$MC_COMMAND\"/" lazymc.toml
-    then
-      echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
-      exit 1
-    fi
-  else
-    if ! sed -i "s/command = .*/command = \"java $JAVA_OPTS -jar $JAR_NAME nogui\"/" lazymc.toml
-    then
-      echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
-      exit 1
-    fi
+    echo "\033[0;31mError: Could not update lazymc.toml. Exiting... \033[0m" | tee server_cfg.txt
+    exit 1
+  fi
 fi
 
 # Server launch handler
@@ -242,19 +234,10 @@ then
   # Start directly the server when lazymc is disabled
   echo "\033[0;33mStarting the server! \033[0m"
   echo ""
-  if $MC_COMMAND != ""
+  if ! java $JAVA_OPTS -jar $JAR_NAME nogui
   then
-    if ! $MC_COMMAND
-    then
-      echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
-      exit 1
-    fi
-  else
-    if ! java $JAVA_OPTS -jar $JAR_NAME nogui
-    then
-      echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
-      exit 1
-    fi
+    echo "\033[0;31mError: Could not start the server. Exiting... \033[0m" | tee server_cfg.txt
+    exit 1
   fi
 else
   echo "\033[0;33mStarting the server! \033[0m"


### PR DESCRIPTION
## .gitignore
- Added docker-compose.yml to prevent upload of testing file

## README.md
- Added RUN_COMMAND Environment variable documentation

## mcserver.sh
- Added Forge Server installation, with a check-file to speed up subsequent runs
- Changed EULA Generation, faster, more consistent, and not dependent on launching the server.
- Added $RUN_COMMAND handling, allowing users to change the start command, useful for debugging, or running user provided Jar files
- Added Forge 1.17.1+ start.sh scraping, allowing simpler automatic forge server setup
- Added server.properties Generation, prevents the server from trying to bind to the same port as lazymc
- Changed Server Launch Handler to use $RUN_COMMAND, allows for changing the run command for the server to support forge 1.17.1+, with the upshot of allowing user customization.

This solves the underlying issue of   [BUG] Lazymc cannot start recent versions of forge #24 